### PR TITLE
chore(nix/home): グローバル LSP をバージョン非依存の言語に限定

### DIFF
--- a/nix/home/lsp.nix
+++ b/nix/home/lsp.nix
@@ -1,19 +1,18 @@
 { pkgs, ... }:
 {
-  # Neovim の config/lsp.lua が vim.lsp.enable するサーバ群を nix で宣言する。
-  # ここが無いと新しいマシンで switch しても各言語を開いた瞬間 LSP が動かない
-  # （＝再現性の穴）。lsp.lua の enable 対象と 1:1 で対応させること。
+  # Neovim の config/lsp.lua が vim.lsp.enable するサーバのうち、
+  # 「プロジェクトのツールチェインにバージョンを合わせる必要が無い」言語だけを
+  # ここで宣言する。エディタ設定と一緒に持ち歩く前提の言語が対象。
+  #
+  # TypeScript / Vue / C# / Go / Rust / C・C++ などバージョン敏感なサーバは
+  # ここに置かない。各プロジェクトの devShell（や node_modules）から供給し、
+  # プロジェクトが pin したバージョンと一致させること。
+  # 例: vue-language-server は @vue/typescript-plugin とメジャーを揃えないと
+  #     hybrid-mode が壊れ、v-on / v-bind 補完が死ぬ。グローバル固定は厳禁。
   home.packages = with pkgs; [
-    gopls # gopls        (Go)
-    rust-analyzer # rust_analyzer (Rust)
-    clang-tools # clangd       (C / C++)
-    lua-language-server # lua_ls       (Lua)
-    nil # nil_ls       (Nix)
-    marksman # marksman     (Markdown)
-    tinymist # tinymist     (Typst)
-    typescript-language-server # ts_ls        (TypeScript / Vue)
-    vue-language-server # vue_ls       (Vue)
-    vscode-langservers-extracted # jsonls       (JSON, vscode-json-language-server を含む)
-    roslyn-ls # roslyn_ls    (C#, Microsoft.CodeAnalysis.LanguageServer)
+    lua-language-server # lua_ls    (Lua)
+    nil # nil_ls    (Nix)
+    marksman # marksman  (Markdown)
+    tinymist # tinymist  (Typst)
   ];
 }


### PR DESCRIPTION
## 背景
`nix/home/lsp.nix` が全 LSP をグローバル宣言していた。しかし `vue-language-server` のようにプロジェクトのツールチェインとメジャー世代を揃える必要があるサーバをグローバル固定すると、プロジェクトが pin した `@vue/typescript-plugin` と世代がズレて hybrid-mode が壊れる。

実害として、frontend/packages/ui（vue-tsc / @vue/typescript-plugin **2.2.12** = v2）に対し、nix グローバルの vue-language-server が **3.2.2**（v3）となり、`v-on` / `v-bind` の補完が効かなくなっていた（`v-if` 等の静的ディレクティブは出る）。

## 変更
- グローバルに残すのは **lua / nix / markdown / typst** のみ（`lua-language-server` / `nil` / `marksman` / `tinymist`）。
- TS・Vue・C#・Go・Rust・C/C++ は各プロジェクトの devShell（or node_modules）供給に委ねる方針へ。
- 方針の理由をコメントに明記（再発防止）。

## 補足
- 恒久解は「プロジェクトと供給元の Vue 世代を揃える」こと。本 PR は"グローバル固定でズレを固定化しない"ためのもの。
- `home-manager switch` は未実施（運用者が適用）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)