### PR TITLE
feat(nvim): add animated start screen logo (mini.starter + tte)

### DIFF
--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -13,6 +13,7 @@
   "lualine.nvim": { "branch": "master", "commit": "47f91c416daef12db467145e16bed5bbfe00add8" },
   "markdown-preview.nvim": { "branch": "master", "commit": "a923f5fc5ba36a3b17e289dc35dc17f66d0548ee" },
   "mini.icons": { "branch": "main", "commit": "efc85e42262cd0c9e1fdbf806c25cb0be6de115c" },
+  "mini.starter": { "branch": "main", "commit": "25de4998197d59673f1918968a8f4060195edca0" },
   "noice.nvim": { "branch": "main", "commit": "7bfd942445fb63089b59f97ca487d605e715f155" },
   "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
   "nvim-autopairs": { "branch": "master", "commit": "59bce2eef357189c3305e25bc6dd2d138c1683f5" },

--- a/.config/nvim/lua/plugins/mini-starter.lua
+++ b/.config/nvim/lua/plugins/mini-starter.lua
@@ -1,0 +1,114 @@
+-- スタート画面 + tte によるロゴアニメーション
+-- 参考: https://zenn.dev/vim_jp/articles/de942e6414685e (issue #12)
+
+-- ロゴ (https://texteditor.com/multiline-text-art/ で作成されたものを拝借)
+local logo = [[
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━ ▄▄    ▄ ▄▄▄▄▄▄▄ ▄▄▄▄▄▄▄ ▄▄   ▄▄ ▄▄ ▄▄   ▄▄ ━━━━━━━━
+━━━━━━━━█  █  █ █       █       █  █ █  █  █  █▄█  █━━━━━━━━
+━━━━━━━━█   █▄█ █    ▄▄▄█   ▄   █  █▄█  █  █       █━━━━━━━━
+━━━━━━━━█       █   █▄▄▄█  █ █  █       █  █       █━━━━━━━━
+━━━━━━━━█  ▄    █    ▄▄▄█  █▄█  █       █  █       █━━━━━━━━
+━━━━━━━━█ █ █   █   █▄▄▄█       ██     ██  █ ██▄██ █━━━━━━━━
+━━━━━━━━█▄█  █▄▄█▄▄▄▄▄▄▄█▄▄▄▄▄▄▄█ █▄▄▄█ █▄▄█▄█   █▄█━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+]]
+
+-- 表示に使う tte のサブコマンド（アニメーション指定）からランダムに1個を使用
+local subcommands = {
+	"middleout --center-movement-speed 0.8 --full-movement-speed 0.2",
+	"slide --merge --movement-speed 0.8",
+	"beams --beam-delay 5 --beam-row-speed-range 20-60 --beam-column-speed-range 8-12",
+}
+
+-- ロゴをフローティングウィンドウに描画する
+local function display_logo()
+	local logo_lines = vim.split(vim.trim(logo), "\n")
+
+	-- 描画用の空バッファ作成
+	local buf = vim.api.nvim_create_buf(false, true)
+
+	-- サイズと位置の指定
+	local line_widths = vim.tbl_map(function(line)
+		return vim.fn.strdisplaywidth(line)
+	end, logo_lines)
+	local width = math.max(unpack(line_widths))
+	local height = #logo_lines + 1
+	local row = 2
+	local col = math.floor((vim.o.columns - width) / 2) -- 左右中央
+
+	local win = vim.api.nvim_open_win(buf, false, {
+		style = "minimal",
+		relative = "editor",
+		width = width,
+		height = height,
+		row = row,
+		col = col,
+		border = "none",
+		focusable = false,
+		noautocmd = true,
+	})
+	vim.api.nvim_set_option_value("winblend", 100, { scope = "local", win = win })
+	-- 非表示になったら wipeout
+	vim.api.nvim_set_option_value("bufhidden", "wipe", { scope = "local", buf = buf })
+
+	if vim.fn.executable("tte") == 1 then
+		math.randomseed(os.time())
+		local subcommand = subcommands[math.random(#subcommands)]
+		local cmd = {
+			"sh",
+			"-c",
+			"printf '%s' "
+				.. vim.fn.shellescape(vim.trim(logo))
+				.. " | tte --anchor-canvas s "
+				.. subcommand
+				.. " --final-gradient-direction diagonal",
+		}
+		-- 作成したバッファをターミナルとしてコマンドを実行
+		vim.api.nvim_buf_call(buf, function()
+			vim.fn.jobstart(cmd, { term = true })
+		end)
+	else
+		-- tte が無い環境では静止ロゴ表示にフォールバック
+		vim.api.nvim_buf_set_lines(buf, 0, -1, false, logo_lines)
+	end
+
+	return { buf = buf, win = win }
+end
+
+return {
+	"nvim-mini/mini.starter",
+	version = false,
+	lazy = false,
+	config = function()
+		-- header に改行を入れてロゴの表示場所を確保する
+		require("mini.starter").setup({
+			header = string.rep("\n", 7),
+		})
+
+		local augroup = vim.api.nvim_create_augroup("start-logo", {})
+		vim.api.nvim_create_autocmd("User", {
+			group = augroup,
+			pattern = "MiniStarterOpened",
+			callback = function()
+				local logo_info = display_logo()
+				-- スタート画面を抜けたらロゴのウィンドウも閉じる
+				-- (bufhidden=wipe なのでバッファも自動で破棄される)
+				vim.api.nvim_create_autocmd("BufLeave", {
+					group = augroup,
+					once = true,
+					buffer = vim.api.nvim_get_current_buf(),
+					callback = function()
+						if vim.api.nvim_win_is_valid(logo_info.win) then
+							vim.api.nvim_win_close(logo_info.win, true)
+						end
+					end,
+					desc = "Close logo",
+				})
+			end,
+			desc = "Display logo when starter opened",
+		})
+	end,
+}

--- a/nix/home/common.nix
+++ b/nix/home/common.nix
@@ -57,6 +57,9 @@
 
       ffmpeg
       poppler-utils
+
+      # Neovim スタート画面のロゴアニメーション用 (tte)
+      terminaltexteffects
     ];
   };
 }


### PR DESCRIPTION
## 概要

Neovim 起動画面にアニメーション付きテキストロゴを表示する。
参考記事: https://zenn.dev/vim_jp/articles/de942e6414685e

Closes #12

## 変更内容

- **`nix/home/common.nix`**: `terminaltexteffects` (tte 0.14.2) を共通パッケージに追加
- **`.config/nvim/lua/plugins/mini-starter.lua`**: `mini.starter` を導入し、`MiniStarterOpened` でフローティングウィンドウを開いて tte のアニメーションをターミナルバッファとして実行
  - サブコマンド (middleout / slide / beams) を起動ごとにランダム選択
  - tte 未導入環境では静止ロゴにフォールバック
  - `BufLeave` でロゴウィンドウを自動クローズ (`bufhidden=wipe` でバッファも破棄)
- **`.config/nvim/lazy-lock.json`**: mini.starter のピン追加

## 検証

- tte 0.14.2 (nixpkgs) で 3 種のサブコマンド + フラグが全て有効なことを確認
- ヘッドレス起動でスタート画面 + フロートの terminal バッファが開くこと、`BufLeave` でフロートが閉じることを確認

## 反映手順 (マージ後)

```sh
home-manager switch --flake .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)